### PR TITLE
Add before_script to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ branches:
   only:
     - master
 
+before_script:
+    - "npm run dist"
+
 script:
     - "npm run test:ci"
 


### PR DESCRIPTION
Tests run against dist bundles. Generate them first in the `before_script` target.