### PR TITLE
Use client LE.createLogStream for better compatibility

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -65,7 +65,10 @@ function getStreams(config) {
     streams.push({
       name: 'logentries',
       level: config.level,
-      stream: new ClientLogentriesLogger({ token: config.logentriesToken }),
+      stream: new ClientLogentriesLogger({
+        name: config.name,
+        token: config.logentriesToken
+      }),
       type: 'raw'
     });
   }

--- a/src/util/client/logentriesLogger.js
+++ b/src/util/client/logentriesLogger.js
@@ -7,8 +7,9 @@ import LE from 'le_js';
 * @param {String} options.token
 * @param {String} options.level
 */
-export default function ClientLogentriesLogger({ token }) {
-  LE.init({
+export default function ClientLogentriesLogger({ name, token }) {
+  this.logentries = LE.createLogStream({
+    name,
     token,
     no_format: true,
     page_info: 'per-page'
@@ -22,9 +23,9 @@ export default function ClientLogentriesLogger({ token }) {
 */
 ClientLogentriesLogger.prototype.write = function (data = {}) {
   const level = bunyan.nameFromLevel[data.level];
-  if (isFunction(LE[level])) {
-    LE[level](data);
+  if (isFunction(this.logentries[level])) {
+    this.logentries[level](data);
   } else {
-    LE.log(data);
+    this.logentries.log(data);
   }
 };

--- a/src/util/common/config.js
+++ b/src/util/common/config.js
@@ -22,11 +22,9 @@ export const DEFAULT_CONFIG = Object.freeze({
  * @returns {Object} runtimeConfig
  */
 export function assembleConfig(config, getStreamsForRuntime) {
-  return Object.assign({},
-    DEFAULT_CONFIG,
-    config,
-    {
-      streams: getStreamsForRuntime(config)
-    }
-  );
+  const baseConfig = Object.assign({}, DEFAULT_CONFIG, config);
+
+  return Object.assign(baseConfig, {
+    streams: getStreamsForRuntime(baseConfig)
+  });
 }

--- a/test/specs/requestLogger.spec.js
+++ b/test/specs/requestLogger.spec.js
@@ -38,6 +38,7 @@ if (typeof document === 'undefined') {
         cb = sinon.stub();
 
         logger = new Logger({
+          stdout: false,
           streams: [
             { type: 'raw', stream: new TestLogger({ cb }) }
           ]


### PR DESCRIPTION
`LE.init` is deprecated and causing test failures in IE < 10.
