### PR TITLE
Add support for Rollbar scrubFields option

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 # ClientLogger
 
-[src/client.js:13-16](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/client.js#L13-L16 "Source code on GitHub")
+[src/client.js:13-16](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/client.js#L13-L16 "Source code on GitHub")
 
 A logger than can be used in browsers
 
@@ -12,66 +12,15 @@ A logger than can be used in browsers
 
 Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** a preconfigured `bunyan` logger instance
 
-# BUNYAN_CONFIG_FIELDS
-
-[src/util/common/config.js:9-14](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/config.js#L9-L14 "Source code on GitHub")
-
-Config keys that should always be passed to
-`bunyan.createLogger`
-
-# DEFAULT_ROOT_FIELDS
-
-[src/util/common/config.js:22-25](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/config.js#L22-L25 "Source code on GitHub")
-
-Whitelist of extra config keys that should be
-passed to `bunyan.createLogger` to form
-root logger fields.
-
-# DEFAULT_CONFIG
-
-[src/util/common/config.js:28-39](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/config.js#L28-L39 "Source code on GitHub")
-
-# assembleConfig
-
-[src/util/common/config.js:52-59](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/config.js#L52-L59 "Source code on GitHub")
-
-Merges config with DEFAULT_CONFIG, and appends passed in streams
-with pre-configured streams for the runtime.
-
-This is used to configure this library, not bunyan as it has a lot of
-extra information. See `toBunyanConfig` below.
-
-**Parameters**
-
--   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
--   `getStreamsForRuntime` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** returns appended config.streams
-
-Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** runtimeConfig
-
-# toBunyanConfig
-
-[src/util/common/config.js:70-72](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/config.js#L70-L72 "Source code on GitHub")
-
-Create a config objct for bunyan from a full `we-js-logger` config object.
-Extra keys passed to `bunyan.createLogger` become root logger fields, pass
-a custom `config.rootFields` to control this behavior
-
-**Parameters**
-
--   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-    -   `config.rootFields` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** extra fields to pass to bunyan
-
-Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** config for bunyan.createLogger
-
 # ClientConsoleLogger
 
-[src/util/client/consoleLogger.js:6-6](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/client/consoleLogger.js#L6-L6 "Source code on GitHub")
+[src/util/client/consoleLogger.js:6-6](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/client/consoleLogger.js#L6-L6 "Source code on GitHub")
 
 Pretty logging to `console` for client applications
 
 ## write
 
-[src/util/client/consoleLogger.js:13-45](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/client/consoleLogger.js#L13-L45 "Source code on GitHub")
+[src/util/client/consoleLogger.js:13-45](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/client/consoleLogger.js#L13-L45 "Source code on GitHub")
 
 Transport to `console`
 
@@ -83,7 +32,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # ClientLogentriesLogger
 
-[src/util/client/logentriesLogger.js:10-16](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/client/logentriesLogger.js#L10-L16 "Source code on GitHub")
+[src/util/client/logentriesLogger.js:10-16](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/client/logentriesLogger.js#L10-L16 "Source code on GitHub")
 
 Custom bunyan stream that transports to Logentries from client applications
 
@@ -96,7 +45,7 @@ Custom bunyan stream that transports to Logentries from client applications
 
 ## write
 
-[src/util/client/logentriesLogger.js:23-30](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/client/logentriesLogger.js#L23-L30 "Source code on GitHub")
+[src/util/client/logentriesLogger.js:23-30](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/client/logentriesLogger.js#L23-L30 "Source code on GitHub")
 
 Transport logs to Logentries
 
@@ -108,7 +57,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # ClientRollbarLogger
 
-[src/util/client/rollbarLogger.js:19-35](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/client/rollbarLogger.js#L19-L35 "Source code on GitHub")
+[src/util/client/rollbarLogger.js:19-36](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/client/rollbarLogger.js#L19-L36 "Source code on GitHub")
 
 Custom rollbar stream that transports to logentries from a browser
 Wortks with a global Rollbar instance that is already initialized.
@@ -125,10 +74,11 @@ integrating Rollbar in client apps
     -   `$0.token`  
     -   `$0.environment`  
     -   `$0.codeVersion`  
+    -   `$0.scrubFields`  
 
 ## write
 
-[src/util/client/rollbarLogger.js:42-48](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/client/rollbarLogger.js#L42-L48 "Source code on GitHub")
+[src/util/client/rollbarLogger.js:43-49](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/client/rollbarLogger.js#L43-L49 "Source code on GitHub")
 
 Transport logs to Rollbar
 
@@ -140,7 +90,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # NodeLogger
 
-[src/node.js:15-24](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/node.js#L15-L24 "Source code on GitHub")
+[src/node.js:15-24](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/node.js#L15-L24 "Source code on GitHub")
 
 A logger than can be used in node processes
 
@@ -150,9 +100,60 @@ A logger than can be used in node processes
 
 Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** a preconfigured `bunyan` logger instance
 
+# BUNYAN_CONFIG_FIELDS
+
+[src/util/common/config.js:9-14](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/config.js#L9-L14 "Source code on GitHub")
+
+Config keys that should always be passed to
+`bunyan.createLogger`
+
+# DEFAULT_ROOT_FIELDS
+
+[src/util/common/config.js:22-25](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/config.js#L22-L25 "Source code on GitHub")
+
+Whitelist of extra config keys that should be
+passed to `bunyan.createLogger` to form
+root logger fields.
+
+# DEFAULT_CONFIG
+
+[src/util/common/config.js:28-40](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/config.js#L28-L40 "Source code on GitHub")
+
+# assembleConfig
+
+[src/util/common/config.js:53-60](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/config.js#L53-L60 "Source code on GitHub")
+
+Merges config with DEFAULT_CONFIG, and appends passed in streams
+with pre-configured streams for the runtime.
+
+This is used to configure this library, not bunyan as it has a lot of
+extra information. See `toBunyanConfig` below.
+
+**Parameters**
+
+-   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `getStreamsForRuntime` **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)** returns appended config.streams
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** runtimeConfig
+
+# toBunyanConfig
+
+[src/util/common/config.js:71-73](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/config.js#L71-L73 "Source code on GitHub")
+
+Create a config objct for bunyan from a full `we-js-logger` config object.
+Extra keys passed to `bunyan.createLogger` become root logger fields, pass
+a custom `config.rootFields` to control this behavior
+
+**Parameters**
+
+-   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+    -   `config.rootFields` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** extra fields to pass to bunyan
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** config for bunyan.createLogger
+
 # ServerRollbarLogger
 
-[src/util/server/rollbarLogger.js:10-17](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/server/rollbarLogger.js#L10-L17 "Source code on GitHub")
+[src/util/server/rollbarLogger.js:10-18](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/server/rollbarLogger.js#L10-L18 "Source code on GitHub")
 
 Custom bunyan stream that transports to Rollbar from a node process.
 See <https://rollbar.com/docs/notifier/node_rollbar/> for integration details
@@ -163,10 +164,11 @@ See <https://rollbar.com/docs/notifier/node_rollbar/> for integration details
     -   `$0.token`  
     -   `$0.codeVersion`  
     -   `$0.environment`  
+    -   `$0.scrubFields`  
 
 ## write
 
-[src/util/server/rollbarLogger.js:27-37](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/server/rollbarLogger.js#L27-L37 "Source code on GitHub")
+[src/util/server/rollbarLogger.js:28-38](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/server/rollbarLogger.js#L28-L38 "Source code on GitHub")
 
 handles `err` and `req` properties, attaches any custom data,
 and calls the appropriate Rollbar method.
@@ -179,7 +181,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # bunyanToRollbarLevelMap
 
-[src/util/common/rollbar.js:9-16](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/rollbar.js#L9-L16 "Source code on GitHub")
+[src/util/common/rollbar.js:9-16](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/rollbar.js#L9-L16 "Source code on GitHub")
 
 Map of bunyan log levels to Rollbar levels
 <https://github.com/trentm/node-bunyan#levels>
@@ -187,7 +189,7 @@ Map of bunyan log levels to Rollbar levels
 
 # bunyanLevelToRollbarLevelName
 
-[src/util/common/rollbar.js:23-26](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/common/rollbar.js#L23-L26 "Source code on GitHub")
+[src/util/common/rollbar.js:23-26](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/common/rollbar.js#L23-L26 "Source code on GitHub")
 
 Convert bunyan log level to rollbar level. Defaults to 'error'.
 
@@ -199,7 +201,7 @@ Returns **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # ServerLogentriesLogger
 
-[src/util/server/logentriesLogger.js:10-19](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/server/logentriesLogger.js#L10-L19 "Source code on GitHub")
+[src/util/server/logentriesLogger.js:10-19](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/server/logentriesLogger.js#L10-L19 "Source code on GitHub")
 
 Custom bunyan stream that transports to logentries from a node process
 
@@ -216,7 +218,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # createRequestLogger
 
-[src/util/server/requestLogger.js:12-48](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/server/requestLogger.js#L12-L48 "Source code on GitHub")
+[src/util/server/requestLogger.js:12-48](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/server/requestLogger.js#L12-L48 "Source code on GitHub")
 
 Create a request loging express middleware
 
@@ -232,7 +234,7 @@ Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ref
 
 # requestLoggerMiddleware
 
-[src/util/server/requestLogger.js:24-47](https://github.com/wework/we-js-logger/blob/1e55e7968e53587841b3875f8117d99cfcb040cc/src/util/server/requestLogger.js#L24-L47 "Source code on GitHub")
+[src/util/server/requestLogger.js:24-47](https://github.com/wework/we-js-logger/blob/be4c68f14ca621ab4eb247cab5e33ca0f8cf6371/src/util/server/requestLogger.js#L24-L47 "Source code on GitHub")
 
 Request Logger Middleware
 Adds base logging to every request

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ const log = new Logger({
     level: 'debug',
     codeVersion: process.env.SHA_VERSION,
     logentriesToken: process.env.LOGENTRIES_TOKEN,
-    rollbarToken: process.env.ROLLBAR_TOKEN
+    rollbarToken: process.env.ROLLBAR_TOKEN,
+    scrubFields: ['password'], // blacklist field keys being sent through logger
 });
 ```
 

--- a/src/client.js
+++ b/src/client.js
@@ -49,7 +49,8 @@ function getStreams(config) {
         stream: new ClientRollbarLogger({
           token: config.rollbarToken,
           environment: config.environment,
-          codeVersion: config.codeVersion
+          codeVersion: config.codeVersion,
+          scrubFields: config.scrubFields,
         }),
         type: 'raw'
       });

--- a/src/node.js
+++ b/src/node.js
@@ -55,7 +55,8 @@ function getStreams(config) {
       stream: new ServerRollbarLogger({
         token: config.rollbarToken,
         environment: config.environment,
-        codeVersion: config.codeVersion
+        codeVersion: config.codeVersion,
+        scrubFields: config.scrubFields,
       }),
       type: 'raw'
     });

--- a/src/util/client/rollbarLogger.js
+++ b/src/util/client/rollbarLogger.js
@@ -16,7 +16,7 @@ export const isGlobalRollbarConfigured = () => !!get(global, 'Rollbar');
  * @param {String} options.environment
  * @param {String} options.codeVersion
  */
-export default function ClientRollbarLogger({ token, environment, codeVersion }) {
+export default function ClientRollbarLogger({ token, environment, codeVersion, scrubFields }) {
   // Rollbar may already be initialized, but thats ok
   // https://rollbar.com/docs/notifier/rollbar.js/configuration/
   global.Rollbar.configure({
@@ -30,7 +30,8 @@ export default function ClientRollbarLogger({ token, environment, codeVersion })
         code_version: codeVersion,
         source_map_enabled: true
       }
-    }
+    },
+    scrubFields,
   });
 }
 

--- a/src/util/common/config.js
+++ b/src/util/common/config.js
@@ -35,7 +35,8 @@ export const DEFAULT_CONFIG = Object.freeze({
   serializers: bunyan.stdSerializers,
   logentriesToken: null,
   rollbarToken: null,
-  rootFields: DEFAULT_ROOT_FIELDS
+  rootFields: DEFAULT_ROOT_FIELDS,
+  scrubFields: [],
 });
 
 /**

--- a/src/util/server/rollbarLogger.js
+++ b/src/util/server/rollbarLogger.js
@@ -7,12 +7,13 @@ import { bunyanLevelToRollbarLevelName } from '../common/rollbar';
  * Custom bunyan stream that transports to Rollbar from a node process.
  * See https://rollbar.com/docs/notifier/node_rollbar/ for integration details
  */
-export default function ServerRollbarLogger({ token, codeVersion, environment }) {
+export default function ServerRollbarLogger({ token, codeVersion, environment, scrubFields }) {
   // https://rollbar.com/docs/notifier/node_rollbar/#configuration-reference
   Rollbar.init(token, {
     handleUncaughtExceptionsAndRejections: true,
     codeVersion,
-    environment
+    environment,
+    scrubFields,
   });
 }
 

--- a/test/specs/logger.spec.js
+++ b/test/specs/logger.spec.js
@@ -71,7 +71,7 @@ describe('we-js-logger', () => {
         logentriesToken: fakeToken
       });
 
-      // The actual logentries steam differs based on runtime env, just
+      // The actual logentries stream differs based on runtime env, just
       // asserting one is there
       expect(log.streams.find((config) => {
         return config.name === 'logentries';
@@ -87,7 +87,7 @@ describe('we-js-logger', () => {
         rollbarToken: fakeToken
       });
 
-      // The actual rollbar steam differs based on runtime env, just
+      // The actual rollbar stream differs based on runtime env, just
       // asserting one is there
       expect(log.streams.find((config) => {
         return config.name === 'rollbar';
@@ -116,6 +116,7 @@ describe('we-js-logger', () => {
       it('does not have extra root fields, such as "rollbarToken"', () => {
         expect(log.fields).not.to.have.property('rollbarToken');
         expect(log.fields).not.to.have.property('logentriesToken');
+        expect(log.fields).not.to.have.property('scrubFields');
         expect(log.fields).not.to.have.property('stdout');
       });
 


### PR DESCRIPTION
Rollbar allows you to pass in a `scrubFields` configuration:
https://rollbar.com/docs/notifier/rollbar.js/configuration/

For example:
```
const logger = new Logger({
  ...
  scrubFields: [
    'password',
    'credit_card',
  ],
});
```