### PR TITLE
make config.scrubFields work globally, not just for Rollbar

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 # ClientLogger
 
-[src/client.js:16-24](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/client.js#L16-L24 "Source code on GitHub")
+[src/client.js:16-24](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/client.js#L16-L24 "Source code on GitHub")
 
 A logger than can be used in browsers
 
@@ -14,13 +14,13 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # ClientConsoleLogger
 
-[src/util/client/consoleLogger.js:6-6](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/consoleLogger.js#L6-L6 "Source code on GitHub")
+[src/util/client/consoleLogger.js:6-6](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/client/consoleLogger.js#L6-L6 "Source code on GitHub")
 
 Pretty logging to `console` for client applications
 
 ## write
 
-[src/util/client/consoleLogger.js:13-45](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/consoleLogger.js#L13-L45 "Source code on GitHub")
+[src/util/client/consoleLogger.js:13-45](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/client/consoleLogger.js#L13-L45 "Source code on GitHub")
 
 Transport to `console`
 
@@ -32,7 +32,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # ClientLogentriesLogger
 
-[src/util/client/logentriesLogger.js:10-16](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/logentriesLogger.js#L10-L16 "Source code on GitHub")
+[src/util/client/logentriesLogger.js:10-16](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/client/logentriesLogger.js#L10-L16 "Source code on GitHub")
 
 Custom bunyan stream that transports to Logentries from client applications
 
@@ -45,7 +45,7 @@ Custom bunyan stream that transports to Logentries from client applications
 
 ## write
 
-[src/util/client/logentriesLogger.js:23-30](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/logentriesLogger.js#L23-L30 "Source code on GitHub")
+[src/util/client/logentriesLogger.js:23-30](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/client/logentriesLogger.js#L23-L30 "Source code on GitHub")
 
 Transport logs to Logentries
 
@@ -57,7 +57,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # ClientRollbarLogger
 
-[src/util/client/rollbarLogger.js:19-35](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/rollbarLogger.js#L19-L35 "Source code on GitHub")
+[src/util/client/rollbarLogger.js:19-35](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/client/rollbarLogger.js#L19-L35 "Source code on GitHub")
 
 Custom rollbar stream that transports to logentries from a browser
 Wortks with a global Rollbar instance that is already initialized.
@@ -77,7 +77,7 @@ integrating Rollbar in client apps
 
 ## write
 
-[src/util/client/rollbarLogger.js:42-48](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/rollbarLogger.js#L42-L48 "Source code on GitHub")
+[src/util/client/rollbarLogger.js:42-48](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/client/rollbarLogger.js#L42-L48 "Source code on GitHub")
 
 Transport logs to Rollbar
 
@@ -89,7 +89,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # NodeLogger
 
-[src/node.js:18-28](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/node.js#L18-L28 "Source code on GitHub")
+[src/node.js:18-28](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/node.js#L18-L28 "Source code on GitHub")
 
 A logger than can be used in node processes
 
@@ -101,14 +101,14 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # BUNYAN_CONFIG_FIELDS
 
-[src/util/common/config.js:9-14](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L9-L14 "Source code on GitHub")
+[src/util/common/config.js:9-14](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/config.js#L9-L14 "Source code on GitHub")
 
 Config keys that should always be passed to
 `bunyan.createLogger`
 
 # DEFAULT_ROOT_FIELDS
 
-[src/util/common/config.js:22-25](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L22-L25 "Source code on GitHub")
+[src/util/common/config.js:22-25](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/config.js#L22-L25 "Source code on GitHub")
 
 Whitelist of extra config keys that should be
 passed to `bunyan.createLogger` to form
@@ -116,18 +116,18 @@ root logger fields.
 
 # BUNYAN_LOGGER_LEVELS
 
-[src/util/common/config.js:32-39](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L32-L39 "Source code on GitHub")
+[src/util/common/config.js:32-32](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/config.js#L32-L32 "Source code on GitHub")
 
 Array of bunyan's different log levels.
 <https://github.com/trentm/node-bunyan#levels>
 
 # DEFAULT_CONFIG
 
-[src/util/common/config.js:42-54](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L42-L54 "Source code on GitHub")
+[src/util/common/config.js:35-47](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/config.js#L35-L47 "Source code on GitHub")
 
 # assembleConfig
 
-[src/util/common/config.js:67-74](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L67-L74 "Source code on GitHub")
+[src/util/common/config.js:60-67](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/config.js#L60-L67 "Source code on GitHub")
 
 Merges config with DEFAULT_CONFIG, and appends passed in streams
 with pre-configured streams for the runtime.
@@ -144,7 +144,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # toBunyanConfig
 
-[src/util/common/config.js:85-87](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L85-L87 "Source code on GitHub")
+[src/util/common/config.js:78-80](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/config.js#L78-L80 "Source code on GitHub")
 
 Create a config objct for bunyan from a full `we-js-logger` config object.
 Extra keys passed to `bunyan.createLogger` become root logger fields, pass
@@ -159,7 +159,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # ServerRollbarLogger
 
-[src/util/server/rollbarLogger.js:10-17](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/rollbarLogger.js#L10-L17 "Source code on GitHub")
+[src/util/server/rollbarLogger.js:10-17](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/server/rollbarLogger.js#L10-L17 "Source code on GitHub")
 
 Custom bunyan stream that transports to Rollbar from a node process.
 See <https://rollbar.com/docs/notifier/node_rollbar/> for integration details
@@ -173,7 +173,7 @@ See <https://rollbar.com/docs/notifier/node_rollbar/> for integration details
 
 ## write
 
-[src/util/server/rollbarLogger.js:27-37](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/rollbarLogger.js#L27-L37 "Source code on GitHub")
+[src/util/server/rollbarLogger.js:27-37](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/server/rollbarLogger.js#L27-L37 "Source code on GitHub")
 
 handles `err` and `req` properties, attaches any custom data,
 and calls the appropriate Rollbar method.
@@ -186,7 +186,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # bunyanToRollbarLevelMap
 
-[src/util/common/rollbar.js:9-16](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/rollbar.js#L9-L16 "Source code on GitHub")
+[src/util/common/rollbar.js:9-16](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/rollbar.js#L9-L16 "Source code on GitHub")
 
 Map of bunyan log levels to Rollbar levels
 <https://github.com/trentm/node-bunyan#levels>
@@ -194,7 +194,7 @@ Map of bunyan log levels to Rollbar levels
 
 # bunyanLevelToRollbarLevelName
 
-[src/util/common/rollbar.js:23-26](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/rollbar.js#L23-L26 "Source code on GitHub")
+[src/util/common/rollbar.js:23-26](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/common/rollbar.js#L23-L26 "Source code on GitHub")
 
 Convert bunyan log level to rollbar level. Defaults to 'error'.
 
@@ -206,7 +206,7 @@ Returns **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # ServerLogentriesLogger
 
-[src/util/server/logentriesLogger.js:10-19](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/logentriesLogger.js#L10-L19 "Source code on GitHub")
+[src/util/server/logentriesLogger.js:10-19](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/server/logentriesLogger.js#L10-L19 "Source code on GitHub")
 
 Custom bunyan stream that transports to logentries from a node process
 
@@ -223,7 +223,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # createRequestLogger
 
-[src/util/server/requestLogger.js:12-48](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/requestLogger.js#L12-L48 "Source code on GitHub")
+[src/util/server/requestLogger.js:12-48](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/server/requestLogger.js#L12-L48 "Source code on GitHub")
 
 Create a request loging express middleware
 
@@ -239,7 +239,7 @@ Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ref
 
 # requestLoggerMiddleware
 
-[src/util/server/requestLogger.js:24-47](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/requestLogger.js#L24-L47 "Source code on GitHub")
+[src/util/server/requestLogger.js:24-47](https://github.com/wework/we-js-logger/blob/63450596a0a4d2b7433ac1afee8dc5d283a82521/src/util/server/requestLogger.js#L24-L47 "Source code on GitHub")
 
 Request Logger Middleware
 Adds base logging to every request

--- a/API.md
+++ b/API.md
@@ -2,7 +2,7 @@
 
 # ClientLogger
 
-[src/client.js:13-16](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/client.js#L13-L16 "Source code on GitHub")
+[src/client.js:16-24](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/client.js#L16-L24 "Source code on GitHub")
 
 A logger than can be used in browsers
 
@@ -14,13 +14,13 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # ClientConsoleLogger
 
-[src/util/client/consoleLogger.js:6-6](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/client/consoleLogger.js#L6-L6 "Source code on GitHub")
+[src/util/client/consoleLogger.js:6-6](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/consoleLogger.js#L6-L6 "Source code on GitHub")
 
 Pretty logging to `console` for client applications
 
 ## write
 
-[src/util/client/consoleLogger.js:13-45](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/client/consoleLogger.js#L13-L45 "Source code on GitHub")
+[src/util/client/consoleLogger.js:13-45](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/consoleLogger.js#L13-L45 "Source code on GitHub")
 
 Transport to `console`
 
@@ -32,7 +32,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # ClientLogentriesLogger
 
-[src/util/client/logentriesLogger.js:10-16](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/client/logentriesLogger.js#L10-L16 "Source code on GitHub")
+[src/util/client/logentriesLogger.js:10-16](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/logentriesLogger.js#L10-L16 "Source code on GitHub")
 
 Custom bunyan stream that transports to Logentries from client applications
 
@@ -45,7 +45,7 @@ Custom bunyan stream that transports to Logentries from client applications
 
 ## write
 
-[src/util/client/logentriesLogger.js:23-30](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/client/logentriesLogger.js#L23-L30 "Source code on GitHub")
+[src/util/client/logentriesLogger.js:23-30](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/logentriesLogger.js#L23-L30 "Source code on GitHub")
 
 Transport logs to Logentries
 
@@ -57,7 +57,7 @@ Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Re
 
 # ClientRollbarLogger
 
-[src/util/client/rollbarLogger.js:19-36](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/client/rollbarLogger.js#L19-L36 "Source code on GitHub")
+[src/util/client/rollbarLogger.js:19-35](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/rollbarLogger.js#L19-L35 "Source code on GitHub")
 
 Custom rollbar stream that transports to logentries from a browser
 Wortks with a global Rollbar instance that is already initialized.
@@ -74,11 +74,10 @@ integrating Rollbar in client apps
     -   `$0.token`  
     -   `$0.environment`  
     -   `$0.codeVersion`  
-    -   `$0.scrubFields`  
 
 ## write
 
-[src/util/client/rollbarLogger.js:43-49](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/client/rollbarLogger.js#L43-L49 "Source code on GitHub")
+[src/util/client/rollbarLogger.js:42-48](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/client/rollbarLogger.js#L42-L48 "Source code on GitHub")
 
 Transport logs to Rollbar
 
@@ -88,29 +87,9 @@ Transport logs to Rollbar
 
 Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)** 
 
-# bunyanToRollbarLevelMap
-
-[src/util/common/rollbar.js:9-16](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/rollbar.js#L9-L16 "Source code on GitHub")
-
-Map of bunyan log levels to Rollbar levels
-<https://github.com/trentm/node-bunyan#levels>
-<https://rollbar.com/docs/notifier/rollbar.js/api/#rollbardebuginfowarnwarningerrorcritical>
-
-# bunyanLevelToRollbarLevelName
-
-[src/util/common/rollbar.js:23-26](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/rollbar.js#L23-L26 "Source code on GitHub")
-
-Convert bunyan log level to rollbar level. Defaults to 'error'.
-
-**Parameters**
-
--   `level` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)](default bunyan.ERROR)** bunyan log level
-
-Returns **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Rollbar log level
-
 # NodeLogger
 
-[src/node.js:15-24](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/node.js#L15-L24 "Source code on GitHub")
+[src/node.js:18-28](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/node.js#L18-L28 "Source code on GitHub")
 
 A logger than can be used in node processes
 
@@ -122,26 +101,33 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # BUNYAN_CONFIG_FIELDS
 
-[src/util/common/config.js:9-14](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/config.js#L9-L14 "Source code on GitHub")
+[src/util/common/config.js:9-14](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L9-L14 "Source code on GitHub")
 
 Config keys that should always be passed to
 `bunyan.createLogger`
 
 # DEFAULT_ROOT_FIELDS
 
-[src/util/common/config.js:22-25](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/config.js#L22-L25 "Source code on GitHub")
+[src/util/common/config.js:22-25](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L22-L25 "Source code on GitHub")
 
 Whitelist of extra config keys that should be
 passed to `bunyan.createLogger` to form
 root logger fields.
 
+# BUNYAN_LOGGER_LEVELS
+
+[src/util/common/config.js:32-39](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L32-L39 "Source code on GitHub")
+
+Array of bunyan's different log levels.
+<https://github.com/trentm/node-bunyan#levels>
+
 # DEFAULT_CONFIG
 
-[src/util/common/config.js:28-40](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/config.js#L28-L40 "Source code on GitHub")
+[src/util/common/config.js:42-54](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L42-L54 "Source code on GitHub")
 
 # assembleConfig
 
-[src/util/common/config.js:53-60](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/config.js#L53-L60 "Source code on GitHub")
+[src/util/common/config.js:67-74](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L67-L74 "Source code on GitHub")
 
 Merges config with DEFAULT_CONFIG, and appends passed in streams
 with pre-configured streams for the runtime.
@@ -158,7 +144,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # toBunyanConfig
 
-[src/util/common/config.js:71-73](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/common/config.js#L71-L73 "Source code on GitHub")
+[src/util/common/config.js:85-87](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/config.js#L85-L87 "Source code on GitHub")
 
 Create a config objct for bunyan from a full `we-js-logger` config object.
 Extra keys passed to `bunyan.createLogger` become root logger fields, pass
@@ -173,7 +159,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # ServerRollbarLogger
 
-[src/util/server/rollbarLogger.js:10-18](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/server/rollbarLogger.js#L10-L18 "Source code on GitHub")
+[src/util/server/rollbarLogger.js:10-17](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/rollbarLogger.js#L10-L17 "Source code on GitHub")
 
 Custom bunyan stream that transports to Rollbar from a node process.
 See <https://rollbar.com/docs/notifier/node_rollbar/> for integration details
@@ -184,11 +170,10 @@ See <https://rollbar.com/docs/notifier/node_rollbar/> for integration details
     -   `$0.token`  
     -   `$0.codeVersion`  
     -   `$0.environment`  
-    -   `$0.scrubFields`  
 
 ## write
 
-[src/util/server/rollbarLogger.js:28-38](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/server/rollbarLogger.js#L28-L38 "Source code on GitHub")
+[src/util/server/rollbarLogger.js:27-37](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/rollbarLogger.js#L27-L37 "Source code on GitHub")
 
 handles `err` and `req` properties, attaches any custom data,
 and calls the appropriate Rollbar method.
@@ -199,9 +184,29 @@ and calls the appropriate Rollbar method.
 
 Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)** 
 
+# bunyanToRollbarLevelMap
+
+[src/util/common/rollbar.js:9-16](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/rollbar.js#L9-L16 "Source code on GitHub")
+
+Map of bunyan log levels to Rollbar levels
+<https://github.com/trentm/node-bunyan#levels>
+<https://rollbar.com/docs/notifier/rollbar.js/api/#rollbardebuginfowarnwarningerrorcritical>
+
+# bunyanLevelToRollbarLevelName
+
+[src/util/common/rollbar.js:23-26](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/common/rollbar.js#L23-L26 "Source code on GitHub")
+
+Convert bunyan log level to rollbar level. Defaults to 'error'.
+
+**Parameters**
+
+-   `level` **\[[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)](default bunyan.ERROR)** bunyan log level
+
+Returns **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Rollbar log level
+
 # ServerLogentriesLogger
 
-[src/util/server/logentriesLogger.js:10-19](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/server/logentriesLogger.js#L10-L19 "Source code on GitHub")
+[src/util/server/logentriesLogger.js:10-19](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/logentriesLogger.js#L10-L19 "Source code on GitHub")
 
 Custom bunyan stream that transports to logentries from a node process
 
@@ -218,7 +223,7 @@ Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 # createRequestLogger
 
-[src/util/server/requestLogger.js:12-48](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/server/requestLogger.js#L12-L48 "Source code on GitHub")
+[src/util/server/requestLogger.js:12-48](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/requestLogger.js#L12-L48 "Source code on GitHub")
 
 Create a request loging express middleware
 
@@ -234,7 +239,7 @@ Returns **[Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Ref
 
 # requestLoggerMiddleware
 
-[src/util/server/requestLogger.js:24-47](https://github.com/wework/we-js-logger/blob/3e15bf00de9f7d15ec06e56e99d8c63c03273ba6/src/util/server/requestLogger.js#L24-L47 "Source code on GitHub")
+[src/util/server/requestLogger.js:24-47](https://github.com/wework/we-js-logger/blob/9969decd2ed8415f12759f3765a900c0fdf294e7/src/util/server/requestLogger.js#L24-L47 "Source code on GitHub")
 
 Request Logger Middleware
 Adds base logging to every request

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "bunyan": "^1.8.2",
     "bunyan-format": "^0.2.1",
+    "hide-secrets": "1.1.0",
     "le_js": "git://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8",
     "le_node": "^1.6.7",
     "lodash": "^4.17.1",

--- a/src/util/client/rollbarLogger.js
+++ b/src/util/client/rollbarLogger.js
@@ -16,7 +16,7 @@ export const isGlobalRollbarConfigured = () => !!get(global, 'Rollbar');
  * @param {String} options.environment
  * @param {String} options.codeVersion
  */
-export default function ClientRollbarLogger({ token, environment, codeVersion, scrubFields }) {
+export default function ClientRollbarLogger({ token, environment, codeVersion }) {
   // Rollbar may already be initialized, but thats ok
   // https://rollbar.com/docs/notifier/rollbar.js/configuration/
   global.Rollbar.configure({
@@ -31,7 +31,6 @@ export default function ClientRollbarLogger({ token, environment, codeVersion, s
         source_map_enabled: true
       }
     },
-    scrubFields,
   });
 }
 

--- a/src/util/common/config.js
+++ b/src/util/common/config.js
@@ -24,6 +24,20 @@ const DEFAULT_ROOT_FIELDS = [
   'release',
 ];
 
+/**
+ * Array of bunyan's different log levels.
+ * https://github.com/trentm/node-bunyan#levels
+ * @type {Array}
+ */
+export const BUNYAN_LOGGER_LEVELS = [
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+]
+
 /** @type {Object} default config to Logger classes */
 export const DEFAULT_CONFIG = Object.freeze({
   name: 'WeWork',

--- a/src/util/common/config.js
+++ b/src/util/common/config.js
@@ -1,4 +1,4 @@
-import bunyan from 'bunyan';
+import bunyan, { levelFromName } from 'bunyan';
 import pick from 'lodash/pick';
 
 /**
@@ -29,14 +29,7 @@ const DEFAULT_ROOT_FIELDS = [
  * https://github.com/trentm/node-bunyan#levels
  * @type {Array}
  */
-export const BUNYAN_LOGGER_LEVELS = [
-  'trace',
-  'debug',
-  'info',
-  'warn',
-  'error',
-  'fatal',
-]
+export const BUNYAN_LOGGER_LEVELS = Object.keys(levelFromName);
 
 /** @type {Object} default config to Logger classes */
 export const DEFAULT_CONFIG = Object.freeze({

--- a/src/util/server/rollbarLogger.js
+++ b/src/util/server/rollbarLogger.js
@@ -7,13 +7,12 @@ import { bunyanLevelToRollbarLevelName } from '../common/rollbar';
  * Custom bunyan stream that transports to Rollbar from a node process.
  * See https://rollbar.com/docs/notifier/node_rollbar/ for integration details
  */
-export default function ServerRollbarLogger({ token, codeVersion, environment, scrubFields }) {
+export default function ServerRollbarLogger({ token, codeVersion, environment }) {
   // https://rollbar.com/docs/notifier/node_rollbar/#configuration-reference
   Rollbar.init(token, {
     handleUncaughtExceptionsAndRejections: true,
     codeVersion,
     environment,
-    scrubFields,
   });
 }
 

--- a/test/specs/logger.spec.js
+++ b/test/specs/logger.spec.js
@@ -99,8 +99,41 @@ describe('we-js-logger', () => {
     it.skip('accepts custom serializers', () => {});
   });
 
+  describe('config.scrubFields', () => {
+    let log;
+
+    beforeEach(() => {
+      log = new Logger({
+        release: { foo: 'bar' },
+        scrubFields: [
+          'scrubMe',
+        ],
+      });
+      log._emit = sinon.stub();
+    });
+
+    describe('hides secrets for fields', () => {
+      it('works', () => {
+        log.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+        expect(log._emit).to.have.been.calledOnce;
+        expect(log._emit.firstCall.args[0].scrubMe).to.equal('[SECRET]');
+        expect(log._emit.firstCall.args[0].tlc).to.equal('No Scrubs');
+      });
+    });
+
+    describe('hides secrets for msg', () => {
+      it('works', () => {
+        log.info('Testing Log', { scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+        expect(log._emit).to.have.been.calledOnce;
+        expect(log._emit.firstCall.args[0].msg).to.equal("Testing Log { scrubMe: '[SECRET]', tlc: 'No Scrubs' }");
+      });
+    });
+  });
+
+
   describe('instance', () => {
     let log;
+
     beforeEach(() => {
       log = new Logger({
         release: { foo: 'bar' }

--- a/test/specs/logger.spec.js
+++ b/test/specs/logger.spec.js
@@ -112,20 +112,38 @@ describe('we-js-logger', () => {
       log._emit = sinon.stub();
     });
 
-    describe('hides secrets for fields', () => {
-      it('works', () => {
-        log.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
-        expect(log._emit).to.have.been.calledOnce;
-        expect(log._emit.firstCall.args[0].scrubMe).to.equal('[SECRET]');
-        expect(log._emit.firstCall.args[0].tlc).to.equal('No Scrubs');
-      });
+    it('hides secrets for fields', () => {
+      log.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+      expect(log._emit).to.have.been.calledOnce;
+      expect(log._emit.firstCall.args[0].scrubMe).to.equal('[SECRET]');
+      expect(log._emit.firstCall.args[0].tlc).to.equal('No Scrubs');
     });
 
-    describe('hides secrets for msg', () => {
-      it('works', () => {
-        log.info('Testing Log', { scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
-        expect(log._emit).to.have.been.calledOnce;
-        expect(log._emit.firstCall.args[0].msg).to.equal("Testing Log { scrubMe: '[SECRET]', tlc: 'No Scrubs' }");
+    it('hides secrets for msg', () => {
+      log.info('Testing Log', { scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+      expect(log._emit).to.have.been.calledOnce;
+      expect(log._emit.firstCall.args[0].msg).to.equal("Testing Log { scrubMe: '[SECRET]', tlc: 'No Scrubs' }");
+    });
+
+    describe('child log', () => {
+      let childLog;
+
+      beforeEach(() => {
+        childLog = log.child({ component: 'child/test' });
+        childLog._emit = sinon.stub();
+      });
+
+      it('hides secrets for fields', () => {
+        childLog.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+        expect(childLog._emit).to.have.been.calledOnce;
+        expect(childLog._emit.firstCall.args[0].scrubMe).to.equal('[SECRET]');
+        expect(childLog._emit.firstCall.args[0].tlc).to.equal('No Scrubs');
+      });
+
+      it('hides secrets for msg', () => {
+        childLog.info('Testing Log', { scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+        expect(childLog._emit).to.have.been.calledOnce;
+        expect(childLog._emit.firstCall.args[0].msg).to.equal("Testing Log { scrubMe: '[SECRET]', tlc: 'No Scrubs' }");
       });
     });
   });


### PR DESCRIPTION
In this pr https://github.com/wework/we-js-logger/pull/47 I added functionality to scrub all fields being passed through before being sent to Rollbar.

This pr extends that functionality to both the `fields` object (first argument in logger functions if it's an object), or the objects you might pass in to be logger messages:

```
// Scrubs `scrubMe` key in both use cases, assuming config.scrubFields == [ 'scrubMe' ]
log.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
log.info('Testing Log', { scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
```