### PR TITLE
Add benchmark vs naked bunyan

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "dist/node.js",
   "browser": "dist/client.js",
   "scripts": {
+    "benchmark": "node test/benchmark",
     "test": "npm run test:browser && npm run test:node && npm run test:leakage",
     "tdd": "npm-run-all --parallel test:*:tdd",
     "test:ci": "npm run test:browser && npm run test:node:ci",
@@ -87,6 +88,7 @@
     "babel-polyfill": "6.20.0",
     "babel-preset-es2015": "6.18.0",
     "babel-preset-stage-0": "6.16.0",
+    "benchmark": "2.1.3",
     "chai": "3.5.0",
     "coveralls": "2.11.15",
     "documentation": "4.0.0-beta11",

--- a/test/benchmark/index.js
+++ b/test/benchmark/index.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-console */
+
+const Benchmark = require('benchmark')
+const bunyan = require('bunyan');
+const WeLogger = require('../..');
+
+var suite = new Benchmark.Suite();
+
+const weLogger = new WeLogger({ stdout: false });
+const bunyanLogger = bunyan.createLogger({ name: 'bunyan', streams: [] });
+
+suite
+  .add('we-js-logger', function() {
+    weLogger.info('hello world')
+  })
+  .add('we-js-logger child', function() {
+    const log = weLogger.child();
+    log.info('hello world');
+  })
+  .add('bunyan', function() {
+    bunyanLogger.info('hello world');
+  })
+  .add('bunyan child', function() {
+    const log = bunyanLogger.child();
+    log.info('hello world');
+  })
+  // add listeners
+  .on('cycle', function(event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function() {
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
+  })
+  // run async
+  .run({ 'async': true });


### PR DESCRIPTION
Resolves #58

`npm run benchmark`:

```
> we-js-logger@0.5.1 benchmark /Users/mnason/code/we-js-logger
> node test/benchmark

we-js-logger x 334,953 ops/sec ±2.09% (83 runs sampled)
we-js-logger child x 154,756 ops/sec ±2.25% (78 runs sampled)
bunyan x 322,868 ops/sec ±1.49% (83 runs sampled)
bunyan child x 229,026 ops/sec ±1.62% (87 runs sampled)
Fastest is we-js-logger
```

I was kind of surprised by this result (I expected bunyan to be faster). It might be because we're not configuring we-js-logger to do anything extra in this benchmark.

Still, this could be helpful with issues such as #54 in the future.