### PR TITLE
Prefer serializers in context to hide-secrets

### DIFF
--- a/src/util/common/logForLevel.js
+++ b/src/util/common/logForLevel.js
@@ -15,6 +15,6 @@ export default function logForLevel(level) {
    * @return {undefined}
    */
   return function logIt(...args) {
-    return this._logger[level].apply(this._logger, scrub(args, this._config));
+    return this._logger[level].apply(this._logger, scrub(args, this._config, this._logger));
   }
 }

--- a/test/specs/logger.spec.js
+++ b/test/specs/logger.spec.js
@@ -113,10 +113,10 @@ describe('we-js-logger', () => {
     });
 
     it('hides secrets for fields', () => {
-      log.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+      log.info({ data: { scrubMe: 'This should be ignored', tlc: 'No Scrubs' } });
       expect(log._logger._emit).to.have.been.calledOnce;
-      expect(log._logger._emit.firstCall.args[0].scrubMe).to.equal('[SECRET]');
-      expect(log._logger._emit.firstCall.args[0].tlc).to.equal('No Scrubs');
+      expect(log._logger._emit.firstCall.args[0].data.scrubMe).to.equal('[SECRET]');
+      expect(log._logger._emit.firstCall.args[0].data.tlc).to.equal('No Scrubs');
     });
 
     it('hides secrets for msg', () => {
@@ -134,10 +134,10 @@ describe('we-js-logger', () => {
       });
 
       it('hides secrets for fields', () => {
-        childLog.info({ scrubMe: 'This should be ignored', tlc: 'No Scrubs' });
+        childLog.info({ data: { scrubMe: 'This should be ignored', tlc: 'No Scrubs' } });
         expect(childLog._logger._emit).to.have.been.calledOnce;
-        expect(childLog._logger._emit.firstCall.args[0].scrubMe).to.equal('[SECRET]');
-        expect(childLog._logger._emit.firstCall.args[0].tlc).to.equal('No Scrubs');
+        expect(childLog._logger._emit.firstCall.args[0].data.scrubMe).to.equal('[SECRET]');
+        expect(childLog._logger._emit.firstCall.args[0].data.tlc).to.equal('No Scrubs');
       });
 
       it('hides secrets for msg', () => {

--- a/test/specs/util/scrub.spec.js
+++ b/test/specs/util/scrub.spec.js
@@ -3,6 +3,8 @@ import scrub from '../../../src/util/common/scrub';
 // FIXME stub out `hideSecrets` -- doesn't seem to be working on first pass
 // import * as hideSecretsModule from 'hide-secrets';
 
+// TODO test special `handleContext` behavior
+
 describe('util/common/scrub', () => {
   let args;
   beforeEach(() => {


### PR DESCRIPTION
If a log method is called with an object as its first argument, bunyan treats it specially as context. Values are passed through serializers, which are usually much more effective than traversing the entire object with `hide-secrets`.

This change makes it so that `scrub` does not touch values of a context object when a serializer has been provided. This should help performance because we no longer need to traverse large, circular `req` and `res` objects.

I'll be adding tests around this as a follow up.