### PR TITLE
Safe access to console for oldIE

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "bunyan": "^1.8.5",
     "bunyan-format": "^0.2.1",
+    "console": "0.5.2",
     "hide-secrets": "1.1.0",
     "le_js": "git://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8",
     "le_node": "^1.7.0",

--- a/src/client.js
+++ b/src/client.js
@@ -9,6 +9,9 @@ import ClientConsoleLogger from './util/client/consoleLogger';
 import ClientLogentriesLogger from './util/client/logentriesLogger';
 import ClientRollbarLogger, { isGlobalRollbarConfigured } from './util/client/rollbarLogger';
 
+// Safe console access for oldIE
+import console from 'console';
+
 /**
  * A logger than can be used in browsers
  * @param   {Object}  config - we-js-logger config

--- a/src/util/client/consoleLogger.js
+++ b/src/util/client/consoleLogger.js
@@ -1,5 +1,8 @@
 import bunyan from 'bunyan';
 
+// Safe console access for oldIE
+import console from 'console';
+
 /**
  * Pretty logging to `console` for client applications
  */


### PR DESCRIPTION
A few of our apps using this library get some traffic from IE <= 9. In those browsers, `console` is undefined unless the developer tools have been opened. Otherwise, an exception is thrown when a console method is invoked.

This passes our use of `console` through the `console` lib, which will stub out console methods for us in this situation https://github.com/matthewhudson/console/blob/master/console.js