### PR TITLE
Exposes rollbar for the node logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "hide-secrets": "1.1.0",
     "le_js": "git://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8",
     "le_node": "^1.7.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.5",
     "rollbar": "^2.3.1",
     "uuid": "3.1.0"
   },

--- a/src/node.js
+++ b/src/node.js
@@ -75,10 +75,10 @@ export default function NodeLogger(config = {}, logger) {
   // Server-specific extras
   this.requestLogger = createRequestLogger(this, serverConfig);
 
-  const rollbar = new Rollbar({
+  this.rollbar = new Rollbar({
     accessToken: config.rollbarToken,
   });
-  this.rollbarErrorMiddleware = rollbar.errorHandler();
+  this.rollbarErrorMiddleware = this.rollbar.errorHandler();
 }
 
 /* eslint-disable prefer-spread, prefer-rest-params */

--- a/test/specs/logger.spec.js
+++ b/test/specs/logger.spec.js
@@ -19,6 +19,12 @@ describe('we-js-logger', () => {
     expect(Logger.bunyanStdSerializers).to.eql(stdSerializers);
   });
 
+  if (typeof document === 'undefined') {
+    it('exposes the rollbar instance', () => {
+      expect(new Logger()).to.have.property('rollbar');
+    });
+  }
+
   describe('options', () => {
     it('accepts a name', () => {
       const name = 'WeTest!';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4438,6 +4438,10 @@ lodash@^4.0.1, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.4, l
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"


### PR DESCRIPTION
CHANGELOG
===

Exposes rollbar as a property of the logger so that it can be used by koa.