### PR TITLE
Adds javascript to root fields of the logger

### DIFF
--- a/src/util/common/config.js
+++ b/src/util/common/config.js
@@ -22,6 +22,7 @@ const BUNYAN_CONFIG_FIELDS = [
 const DEFAULT_ROOT_FIELDS = [
   'environment',
   'release',
+  'javascript',
 ];
 
 /**

--- a/test/specs/logger.spec.js
+++ b/test/specs/logger.spec.js
@@ -166,6 +166,7 @@ describe('we-js-logger', () => {
     beforeEach(() => {
       log = new Logger({
         release: { foo: 'bar' },
+        javascript: { browser: 'Chrome' },
       });
     });
 
@@ -190,6 +191,10 @@ describe('we-js-logger', () => {
         });
         expect(customLog._logger.fields).to.have.property('badIdea');
         expect(customLog._logger.fields).not.to.have.property('release');
+      });
+
+      it('should allow the javascript field', () => {
+        expect(log._logger.fields).to.have.property('javascript');
       });
     });
 


### PR DESCRIPTION
CHANGELOG
==

- Allows clients to pass in browser/javascript fields to be logged