### PR TITLE
Fixed error during yarn/npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules
 
 # ESLint Cache
 .eslintcache
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -8642,7 +8642,7 @@
       "dev": true
     },
     "le_js": {
-      "version": "git://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8"
+      "version": "https://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8"
     },
     "le_node": {
       "version": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bunyan-format": "^0.2.1",
     "console": "0.5.2",
     "hide-secrets": "1.1.0",
-    "le_js": "git://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8",
+    "le_js": "https://github.com/nason/le_js.git#7a75be7c1dd2438e3f1183a68bd2162b80bc94d8",
     "le_node": "^1.7.0",
     "lodash": "^4.17.5",
     "rollbar": "^2.3.1",


### PR DESCRIPTION
npm ERR! fatal: remote error:
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR!

Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information